### PR TITLE
Allow Area mouse events in Bullet physics without collision layer.

### DIFF
--- a/modules/bullet/godot_result_callbacks.cpp
+++ b/modules/bullet/godot_result_callbacks.cpp
@@ -57,7 +57,7 @@ bool GodotFilterCallback::needBroadphaseCollision(btBroadphaseProxy *proxy0, btB
 
 bool GodotClosestRayResultCallback::needsCollision(btBroadphaseProxy *proxy0) const {
 	const bool needs = GodotFilterCallback::test_collision_filters(m_collisionFilterGroup, m_collisionFilterMask, proxy0->m_collisionFilterGroup, proxy0->m_collisionFilterMask);
-	if (needs) {
+	if (m_pickRay || needs) {
 		btCollisionObject *btObj = static_cast<btCollisionObject *>(proxy0->m_clientObject);
 		CollisionObjectBullet *gObj = static_cast<CollisionObjectBullet *>(btObj->getUserPointer());
 


### PR DESCRIPTION
[> I have no idea how to do it for Bullet. It could be done in another PR, by someone who is more knowledgeable on that regard.](https://github.com/godotengine/godot/pull/40193#issuecomment-655826273)

This provides the same solution in Bullet physics.